### PR TITLE
Fix 'Array to string' conversion issue

### DIFF
--- a/classes/form/create_dkim.php
+++ b/classes/form/create_dkim.php
@@ -47,11 +47,11 @@ class create_dkim extends \moodleform {
 
         $group = [];
 
-        $group[] =& $mform->createElement('text', 'domain', '', array("size" => 20));
+        $group[] =& $mform->createElement('text', 'domain', '', ["size" => 20]);
         $mform->setDefault("domain", $noreplydomain);
         $mform->setType('domain', PARAM_HOST);
 
-        $group[] =& $mform->createElement('text', 'selector', '', array("size" => 20));
+        $group[] =& $mform->createElement('text', 'selector', '', ["size" => 20]);
 
         $selector = $this->get_default_selector();
         $mform->setDefault("selector", $selector);

--- a/classes/form/create_dkim.php
+++ b/classes/form/create_dkim.php
@@ -47,11 +47,11 @@ class create_dkim extends \moodleform {
 
         $group = [];
 
-        $group[] =& $mform->createElement('text', 'domain', array("size" => 20));
+        $group[] =& $mform->createElement('text', 'domain', '', array("size" => 20));
         $mform->setDefault("domain", $noreplydomain);
         $mform->setType('domain', PARAM_HOST);
 
-        $group[] =& $mform->createElement('text', 'selector', array("size" => 20));
+        $group[] =& $mform->createElement('text', 'selector', '', array("size" => 20));
 
         $selector = $this->get_default_selector();
         $mform->setDefault("selector", $selector);


### PR DESCRIPTION
**Description:** Site is experiencing the following issue when visiting `admin/tool/emailutils/dkim.php`:

```
Notice: Array to string conversion in /var/lib/sitedata/localcache/mustache/1707376349/catawesome/__Mustache_e3578c6a96c88ede4f6099664aaa9b01.php on line 179

Notice: Array to string conversion in /var/lib/sitedata/localcache/mustache/1707376349/catawesome/__Mustache_e3578c6a96c88ede4f6099664aaa9b01.php on line 179
```
This error is caused by the two form elements that are created:

```php
$group[] =& $mform->createElement('text', 'domain', array("size" => 20));
$group[] =& $mform->createElement('text', 'selector', array("size" => 20));
```

Using Xdebug, the two elements have the following values represented as JSON-like object. The label is expecting a language string, but is given an array. This size parameter should be included in the attributes array.

```
{
  label: [
    size = 20
  ],
  attributes: [
    name = "selector",
    type = "text",
    value = "..."
  ]
}
```

Making the following change to both elements in the group resolves the error:
```php
$group[] =& $mform->createElement('text', 'domain', '', array("size" => 20));
$group[] =& $mform->createElement('text', 'selector', '', array("size" => 20));
```
This change is also aligned with the `createElement`s in [tool_abconfig](https://github.com/catalyst/moodle-tool_abconfig/blob/965a4ccc9f8cdbba5fb7d2274d3257481625f6c2/classes/form/edit_conditions.php#L147)
```php
$repeatarray[] = $mform->createElement(
        "textarea",
        "repeatiplist",
        get_string("formipwhitelist", "tool_abconfig"),
        array(
            "placeholder" => '127.0.0.1',
            "rows" => 3,
            "cols" => 60
        )
    );
```
