### PR TITLE
fix: reduce error levels to warn only

### DIFF
--- a/classes/check/dnsdmarc.php
+++ b/classes/check/dnsdmarc.php
@@ -75,7 +75,7 @@ class dnsdmarc extends check {
 
         if (empty($dmarc)) {
             $details .= "<p>DMARC record is missing</p>";
-            $status = result::ERROR;
+            $status = result::WARNING;
             $summary = "DMARC DNS record missing";
         } else {
             $details .= "<p>DMARC record found on domain <code>$dmarcdomain</code><br><code>$dmarc</code></p>";

--- a/classes/check/dnsmx.php
+++ b/classes/check/dnsmx.php
@@ -75,7 +75,7 @@ class dnsmx extends check {
 
         if (empty($mxdomains)) {
             $details .= "<p>MX record is missing</p>";
-            $status = result::ERROR;
+            $status = result::WARNING;
             $summary = "MX DNS record missing";
         } else {
             $allmxdomains = join('<br>', array_map(function ($x) {


### PR DESCRIPTION
Not everyone MUST currently use mx or dmarc to send and receive email.
e.g. a particular LMS might not utilise mx records at all.
