### PR TITLE
Relax postmaster checks #51

### DIFF
--- a/classes/check/dnsmx.php
+++ b/classes/check/dnsmx.php
@@ -78,9 +78,7 @@ class dnsmx extends check {
             $status = result::WARNING;
             $summary = "MX DNS record missing";
         } else {
-            $allmxdomains = join('<br>', array_map(function ($x) {
-                return $x['target'] . ' (' . $x['pri'] . ')';
-            }, $mxdomains));
+            $allmxdomains = $dns->format_mx_records($mxdomains);
             $details .= "<p>MX record found on domain <code>$noreplydomain</code> pointing to<br><code>$allmxdomains</code></p>";
             $status = result::OK;
             $summary = "MX record points to " . $mxdomains[0]['target'];

--- a/lang/en/tool_emailutils.php
+++ b/lang/en/tool_emailutils.php
@@ -59,6 +59,7 @@ $string['dnsspfinclude'] = 'SPF include';
 $string['dnsspfinclude_help'] = '<p>This is an SPF include domain which is expected to be present in the record. For example if this was set to <code>spf.acme.org</code> then the SPF security check would pass if the SPF record was <code>v=spf1 include:spf.acme.org -all</code>.</p>
 <p>The * char can be used as a wildcard eg <code>*acme.org</code> would also match.</p>
 ';
+$string['domain'] = 'Domain';
 $string['domaindefaultnoreply'] = 'Default noreply';
 $string['downloadsuppressionlist'] = 'Download Suppression List';
 $string['enabled'] = 'Enabled';
@@ -68,6 +69,8 @@ $string['header'] = 'Header';
 $string['header_help'] = 'HTTP Basic Auth Header';
 $string['incorrect_access'] = 'Incorrect access detected. For use only by AWS SNS.';
 $string['list'] = 'Complaints List';
+$string['noreplyemail'] = 'No reply email: <code>{$a}</code>';
+$string['mxrecords'] = 'MX records';
 $string['mxtoolbox'] = 'MXtoolbox links';
 $string['not_implemented'] = 'Not implemented yet. Search the user report for emails ending with ".b.invalid" and ".c.invalid".';
 $string['password'] = 'Password';
@@ -103,3 +106,5 @@ $string['suppressionlistdesc'] = 'Download the email suppression list from AWS S
 $string['task_update_suppression_list'] = 'Update email suppression list';
 $string['username'] = 'Username';
 $string['username_help'] = 'HTTP Basic Auth Username';
+$string['userdomains'] = 'Most common user email domains';
+$string['vendor'] = 'Vendor';

--- a/templates/postmaster.mustache
+++ b/templates/postmaster.mustache
@@ -1,0 +1,83 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template tool_emailutils/postmaster
+
+    Example context (json):
+    {
+        "noreply": "noreply@example.com",
+        "userdomains": [
+            {
+                "domain": "@gmail.com",
+                "count": 100,
+                "mxrecords": "string",
+                "vendor": "google",
+            }
+        ],
+        "vendorinfo": [
+            {
+                "vendors": "google",
+                "token": "token",
+                "confirmed": "N/A",
+                "url": "https://example.com",
+            }
+        ],
+    }
+}}
+<p>{{#str}} noreplyemail, tool_emailutils, {{ noreply }} {{/str}}</p>
+<table class="admintable generaltable table-sm w-auto">
+    <thead>
+    <tr>
+        <th>{{#str}} vendor, tool_emailutils {{/str}}</th>
+        <th>{{#str}} token, core_webservice {{/str}}</th>
+        <th>{{#str}} confirmed, core_admin {{/str}}</th>
+        <th>{{#str}} url {{/str}}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{#vendorinfo}}
+        <tr>
+            <td>{{ vendor }}</td>
+            <td>{{ token }}</td>
+            <td>{{ confirmed }}</td>
+            <td>{{ url }}</td>
+        </tr>
+    {{/vendorinfo}}
+    </tbody>
+</table>
+
+<h5>{{#str}} userdomains, tool_emailutils {{/str}}</h5>
+<table class="admintable generaltable table-sm w-auto">
+    <thead>
+    <tr>
+        <th>{{#str}} domain, tool_emailutils {{/str}}</th>
+        <th>{{#str}} users {{/str}}</th>
+        <th>{{#str}} mxrecords, tool_emailutils {{/str}}</th>
+        <th>{{#str}} vendor, tool_emailutils {{/str}}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{#userdomains}}
+        <tr>
+            <td>{{ domain }}</td>
+            <td>{{ count }}</td>
+            <td><code>{{{ mxrecords }}}</code>
+            <td>{{ vendors }}</td>
+        </tr>
+    {{/userdomains}}
+    </tbody>
+</table>

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2024100101;
-$plugin->release  = 2024011502;
+$plugin->version  = 2024101700;
+$plugin->release  = 2024101700;
 $plugin->requires = 2020061500;
 $plugin->component = 'tool_emailutils';
 $plugin->dependencies = ['local_aws' => 2020061500];


### PR DESCRIPTION
Relaxed postmaster checks and added checking based on user email domains.

A couple of notes:
- The check on user domains is limited to the 5 most common for the mx lookup, but did we also want an additional check on gmail domains outside the top 5? If so should there be a minimum?
- Both tables in this check are rendered very roughly. Ideally they should use a proper template.

Closes #51 