### PR TITLE
Add proper support for Moodle 4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
       disable_behat: true
       disable_grunt: true
       disable_mustache: true
-      extra_plugin_runners: |
-        moodle-plugin-ci add-plugin catalyst/moodle-local_aws

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ A rough roadmap with no set timelines:
 ## Branches
 The following lists the supported branch to use based on your Moodle version.
 
-| Moodle version | Branch           |
-|----------------|------------------|
-| Moodle 3.9+    | MOODLE_39_STABLE |
+| Moodle version | Branch            |
+|----------------|-------------------|
+| Moodle 3.9-4.3 | MOODLE_39_STABLE  |
+| Moodle 4.4+    | MOODLE_404_STABLE |
 
 ## Installation
 

--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_emailutils;
+
+/**
+ * Hook callbacks for tool_emailutils.
+ *
+ * @package   tool_emailutils
+ * @author    Benjamin Walker (benjaminwalker@catalyst-au.net)
+ * @copyright 2024 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+
+    /**
+     * This adds a new bulk user action to reset a persons bounce count.
+     *
+     * @param \core_user\hook\extend_bulk_user_actions $hook
+     */
+    public static function extend_bulk_user_actions(\core_user\hook\extend_bulk_user_actions $hook): void {
+        if (has_capability('moodle/site:config', \context_system::instance())) {
+            $hook->add_action('tool_ses_reset_bounces', new \action_link(
+                new \moodle_url('/admin/tool/emailutils/reset_bounces.php'),
+                get_string('resetbounces', 'tool_emailutils')
+            ));
+        }
+    }
+}

--- a/classes/sns_client.php
+++ b/classes/sns_client.php
@@ -27,8 +27,6 @@ namespace tool_emailutils;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php');
-
 use Aws\Sns\Exception\InvalidSnsMessageException;
 use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;

--- a/classes/task/update_suppression_list.php
+++ b/classes/task/update_suppression_list.php
@@ -27,12 +27,6 @@ namespace tool_emailutils\task;
 
 defined('MOODLE_INTERNAL') || die();
 
-if (!class_exists('\Aws\SesV2\SesV2Client')) {
-    if (file_exists($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php')) {
-        require_once($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php');
-    }
-}
-
 /**
  * Scheduled task class for updating the email suppression list.
  *

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,27 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Lib
+ * Hook callbacks for tool_emailutils
  *
- * @package    tool_emailutils
- * @copyright  2018 onwards Catalyst IT {@link http://www.catalyst-eu.net/}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author     Harry Barnard <harry.barnard@catalyst-eu.net>
+ * @package   tool_emailutils
+ * @author    Benjamin Walker (benjaminwalker@catalyst-au.net)
+ * @copyright 2024 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-/**
- * Security checks.
- *
- * @return array
- */
-function tool_emailutils_security_checks() {
-    return [
-        new \tool_emailutils\check\dnsspf(),
-        new \tool_emailutils\check\dnsdkim(),
-        new \tool_emailutils\check\dnsdmarc(),
-        new \tool_emailutils\check\dnsmx(),
-        new \tool_emailutils\check\dnsnoreply(),
-        new \tool_emailutils\check\dnspostmastertools(),
-    ];
-}
+defined('MOODLE_INTERNAL') || die();
 
+$callbacks = [
+    [
+        'hook' => \core_user\hook\extend_bulk_user_actions::class,
+        'callback' => '\tool_emailutils\hook_callbacks::extend_bulk_user_actions',
+        'priority' => 0,
+    ],
+];

--- a/tests/suppressionlist_test.php
+++ b/tests/suppressionlist_test.php
@@ -19,12 +19,6 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 
-if (!class_exists('\Aws\SesV2\SesV2Client')) {
-    if (file_exists($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php')) {
-        require_once($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php');
-    }
-}
-
 /**
  * Test case for suppression list functionality.
  *

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2024111300;
-$plugin->release  = 2024111300;
+$plugin->version  = 2024111301;
+$plugin->release  = 2024111301;
 $plugin->requires = 2024042200;
 $plugin->component = 'tool_emailutils';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,10 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2024101700;
-$plugin->release  = 2024101700;
-$plugin->requires = 2020061500;
+$plugin->version  = 2024111300;
+$plugin->release  = 2024111300;
+$plugin->requires = 2024042200;
 $plugin->component = 'tool_emailutils';
-$plugin->dependencies = ['local_aws' => 2020061500];
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [39, 404];
+$plugin->supported = [404, 405];


### PR DESCRIPTION
- Split at 4.4 because aws sdk was added to core
- Removes local_ aws requirement
- Add new hook callback for extend_bulk_user_actions (Closes #50) 