### PR TITLE
Use XMLDB Editor to format tool_emailutils_suppression table definition

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/emailutils/db" VERSION="2024100101" COMMENT="XMLDB file for plugin admin/tool/emailutils"
+<XMLDB PATH="admin/tool/emailutils/db" VERSION="20241001" COMMENT="XMLDB file for plugin admin/tool/emailutils"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -37,8 +37,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="email" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="reason" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="created_at" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" 
-        COMMENT="Timestamp from AWS SES API, different from timecreated. Represents when the email was added to the suppression list."/>
+        <FIELD NAME="created_at" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="Timestamp from AWS SES API, different from timecreated. Represents when the email was added to the suppression list."/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>


### PR DESCRIPTION
**Description:** Unit tests were failing in Totara 17 due to the format of the `tool_emailutils_suppression` table in `db/install.xml`

## Problem
test_all_install_xml_files_formatted_correctly server/admin/tool/xmldb/tests/install_xml_test.php
```
1) tool_xmldb_instal_xml_testcase::test_all_install_xml_files_formatted_correctly
XMLDB file '/var/www/tests-totara/server/admin/tool/emailutils/db/install.xml' is different to the generated version, please edit the file in XMLDB editor and save it.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="email" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="reason" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="created_at" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false"
-        COMMENT="Timestamp from AWS SES API, different from timecreated. Represents when the email was added to the suppression list."/>
+        <FIELD NAME="created_at" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="Timestamp from AWS SES API, different from timecreated. Represents when the email was added to the suppression list."/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>

/var/www/tests-totara/server/admin/tool/xmldb/tests/install_xml_test.php:52
/var/www/tests-totara/server/lib/phpunit/classes/testcase.php:114
```

This is occurring because there is a new line in the db/install.xml for emailutils:

```
    <TABLE NAME="tool_emailutils_suppression" COMMENT="Stores the email suppression list">
      <FIELDS>
        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
        <FIELD NAME="email" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
        <FIELD NAME="reason" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false"/>
        <FIELD NAME="created_at" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" 
        COMMENT="Timestamp from AWS SES API, different from timecreated. Represents when the email was added to the suppression list."/>
        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
      </FIELDS>
      <KEYS>
        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
      </KEYS>
    </TABLE>
```

Removing this new line and moving COMMENT to the previously line resolves this unit test.

## Solution:

Use XMLDB Editor to format the table definition