### PR TITLE
Remove incompatible to maintain 310 support

### DIFF
--- a/version.php
+++ b/version.php
@@ -32,4 +32,3 @@ $plugin->component = 'tool_emailutils';
 $plugin->dependencies = ['local_aws' => 2020061500];
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [39, 403];
-$plugin->incompatible = 405; // Limited support for 4.4.


### PR DESCRIPTION
Previous tests were failing CI for Moodle 3.10 because $plugin->incompatible doesn't work correctly there - it was initially fixed in https://tracker.moodle.org/browse/MDL-72324 and then backported to 3.9 https://tracker.moodle.org/browse/MDL-77128 but never to 3.10

Simplest option is just to not include this for now.  
