### PR TITLE
Fix html writer namespace on 4.4

### DIFF
--- a/classes/reportbuilder/local/entities/email_bounce.php
+++ b/classes/reportbuilder/local/entities/email_bounce.php
@@ -17,7 +17,6 @@
 namespace tool_emailutils\reportbuilder\local\entities;
 
 use lang_string;
-use core\output\html_writer;
 use core_reportbuilder\local\entities\base;
 use core_reportbuilder\local\filters\number;
 use core_reportbuilder\local\report\column;
@@ -107,7 +106,7 @@ class email_bounce extends base {
             ->set_is_sortable(true)
             ->add_callback(function(int $value): string {
                 if ($value >= helper::get_min_bounces()) {
-                    return html_writer::span($value, 'alert alert-danger p-2');
+                    return \html_writer::span($value, 'alert alert-danger p-2');
                 }
                 return $value;
             });
@@ -139,7 +138,7 @@ class email_bounce extends base {
             ->add_callback(function(?float $value): string {
                 $float = format_float($value, 2);
                 if ($value > helper::get_bounce_ratio()) {
-                    return html_writer::span($float, 'alert alert-danger p-2');
+                    return \html_writer::span($float, 'alert alert-danger p-2');
                 }
                 return $float;
             });

--- a/classes/reportbuilder/local/entities/notification_log.php
+++ b/classes/reportbuilder/local/entities/notification_log.php
@@ -17,7 +17,6 @@
 namespace tool_emailutils\reportbuilder\local\entities;
 
 use lang_string;
-use core\output\html_writer;
 use core_reportbuilder\local\entities\base;
 use core_reportbuilder\local\filters\date;
 use core_reportbuilder\local\filters\text;
@@ -123,9 +122,9 @@ class notification_log extends base {
                 if (empty($subtypes)) {
                     return '';
                 } else if (in_array($subtypes, sns_notification::BLOCK_IMMEDIATELY)) {
-                    return html_writer::span($subtypes, 'alert alert-danger p-2');
+                    return \html_writer::span($subtypes, 'alert alert-danger p-2');
                 } else if (in_array($subtypes, sns_notification::BLOCK_IMMEDIATELY)) {
-                    return html_writer::span($subtypes, 'alert alert-warning p-2');
+                    return \html_writer::span($subtypes, 'alert alert-warning p-2');
                 }
                 return $subtypes;
             });


### PR DESCRIPTION
The previous namespace for html writer from #88 only works on 4.5+