### PR TITLE
Replace deprecated setMethods with onlyMethods

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -35,8 +35,8 @@ use core_privacy\local\request\{approved_contextlist, approved_userlist, context
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements
-    \core_privacy\local\request\core_userlist_provider,
     \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\core_userlist_provider,
     \core_privacy\local\request\plugin\provider {
     /**
      * Returns metadata.

--- a/tests/suffix_test.php
+++ b/tests/suffix_test.php
@@ -40,7 +40,7 @@ final class suffix_test extends \advanced_testcase {
     public function test_suffix(string $lmsdomain, string $noreplydomain, string $primarydomain, string $selectorsuffix): void {
         $this->resetAfterTest();
         $mock = $this->getMockBuilder('\tool_emailutils\dns_util')
-            ->setMethods(['get_primary_domain', 'get_noreply_domain'])
+            ->onlyMethods(['get_primary_domain', 'get_noreply_domain'])
             ->getMock();
 
         $mock->expects($this->any())

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2024112901;
-$plugin->release  = 2024112901;
+$plugin->version  = 2024112902;
+$plugin->release  = 2024112902;
 $plugin->requires = 2024042200;
 $plugin->component = 'tool_emailutils';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Description:** Replace deprecated setMethods with onlyMethods. Test still runs successfully in Moodle 4.5:

```
root@2148dbd199be:/var/www/cat-moo# vendor/bin/phpunit admin/tool/emailutils/tests/suffix_test.php
Moodle 4.5.11+ (Build: 20260501), 38becfa44d6eaaf99250c36f3848b9d76e135a78
Php: 8.3.31, pgsql: 17.10 (Debian 17.10-1.pgdg13+1), OS: Linux 6.17.0-29-generic x86_64
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

.............                                                     13 / 13 (100%)

Time: 00:01.422, Memory: 48.00 MB

OK (13 tests, 13 assertions)
```