### PR TITLE
Issue #105: Added nullable flag to $certClient

### DIFF
--- a/lib/aws-sns-message-validator/src/MessageValidator.php
+++ b/lib/aws-sns-message-validator/src/MessageValidator.php
@@ -62,7 +62,7 @@ class MessageValidator
      * @param string $hostNamePattern
      */
     public function __construct(
-        callable $certClient = null,
+        ?callable $certClient = null,
         $hostNamePattern = ''
     ) {
         $this->certClient = $certClient ?: function($certUrl) {


### PR DESCRIPTION
Closes issue #105.

Updated `aws::MessageValidator` constructor with `?` nullable flag for $certClient to fix deprecation warning during unit tests.

## Environment
```
- Moodle 5.1.5+ (Build: 20260714)
- PHP: 8.4.22
- DB: MySQL 8.4
- PHPUnit: 11.5.55
- Branch: MOODLE_404_STABLE
```

## Testing instructions:
- `tool_emailutils` test suite: `vendor/bin/phpunit --testsuite tool_emailutils_testsuite`
- Running the unit tests for `tool_emailutils` will produce the following warning (on the above environment):
```
Moodle 5.1.5+ (Build: 20260714)
Php: 8.4.22, mysqli: 8.4.10, OS: Linux 6.17.0-1028-oem x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-plugins/phpunit.xml

SD......................                                          24 / 24 (100%)

Time: 00:02.132, Memory: 74.50 MB

1 test triggered 1 PHP deprecation:

1) /var/www/upstream-plugins/public/admin/tool/emailutils/lib/aws-sns-message-validator/src/MessageValidator.php:64
Aws\Sns\MessageValidator::__construct(): Implicitly marking parameter $certClient as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* tool_emailutils\sns_client_test::test_lib
  /var/www/upstream-plugins/public/admin/tool/emailutils/tests/sns_client_test.php:43

OK, but there were issues!
Tests: 24, Assertions: 65, Deprecations: 1, PHPUnit Deprecations: 7, Skipped: 1.
```
### Expected Output from PHPUnit Tests
- Pulling this branch `MOODLE_404_STABLE-issue105` and re-running the testsuite:
```
Moodle 5.1.5+ (Build: 20260714)
Php: 8.4.22, mysqli: 8.4.10, OS: Linux 6.17.0-1028-oem x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-plugins/phpunit.xml

S.......................                                          24 / 24 (100%)

Time: 00:02.144, Memory: 72.50 MB

OK, but there were issues!
Tests: 24, Assertions: 65, PHPUnit Deprecations: 7, Skipped: 1.

```